### PR TITLE
Add support for passing options to the Docker daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Ansible role for installing Docker.
 ## Role Variables
 
 - `docker_version` - Docker version
+- `docker_options` - Options passed to the Docker daemon
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 docker_version: "1.2.0"
+docker_options: ""

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart Docker
+  service: name=docker state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,3 +7,8 @@
 
 - name: Install Docker
   apt: pkg=lxc-docker-{{ docker_version }}={{ docker_version }} state=present
+
+- name: Configure Docker
+  template: src=docker.j2 dest=/etc/default/docker
+  notify:
+    - Restart Docker

--- a/templates/docker.j2
+++ b/templates/docker.j2
@@ -1,0 +1,13 @@
+# Docker Upstart and SysVinit configuration file
+
+# Customize location of Docker binary (especially for development testing).
+#DOCKER="/usr/local/bin/docker"
+
+# Use DOCKER_OPTS to modify the daemon startup options.
+DOCKER_OPTS="{{ docker_options }}"
+
+# If you need Docker to use an HTTP proxy, it can also be specified here.
+#export http_proxy="http://127.0.0.1:3128/"
+
+# This is also a handy place to tweak where Docker's temporary files go.
+#export TMPDIR="/mnt/bigdrive/docker-tmp"


### PR DESCRIPTION
The Upstart support for Ubuntu provides a defaults file to override default options to the Docker daemon. This change allows us to alter `DOCKER_OPTS` in that file to support custom Docker daemon options.
