### PR TITLE
Update APT repository for Docker engine

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-docker_version: "1.7.0"
+docker_version: "1.7.*"
 docker_py_version: "1.2.3"
 docker_options: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,16 @@
 ---
 - name: Configure the Docker APT key
-  apt_key: url=https://get.docker.io/gpg state=present
+  apt_key: url=https://get.docker.io/gpg
+           keyserver=p80.pool.sks-keyservers.net
+           id=58118E89F3A912897C070ADBF76221572C52609D
+           state=present
 
 - name: Configure the Docker APT repository
-  apt_repository: repo="deb https://get.docker.io/ubuntu docker main" state=present
+  apt_repository: repo="deb https://apt.dockerproject.org/repo {{ ansible_distribution|lower }}-{{ ansible_distribution_release }} main"
+                  state=present
 
 - name: Install Docker
-  apt: pkg=lxc-docker-{{ docker_version }}={{ docker_version }} state=present
+  apt: pkg=docker-engine={{ docker_version }} state=present
 
 - name: Configure Docker
   template: src=docker.j2 dest=/etc/default/docker


### PR DESCRIPTION
Docker recently updated their package repositories. These changes add support for the new repositories to this role.

For more details on the change, see: http://blog.docker.com/2015/07/new-apt-and-yum-repos/

If you're running this on a system that was using an older version of this role, please ensure that you remove the older Docker package name first:

```
$ sudo apt-get purge lxc-docker*
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/azavea/ansible-docker/4)

<!-- Reviewable:end -->
