### PR TITLE
Make AUFS the default storage driver

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 docker_version: "1.7.*"
 docker_py_version: "1.2.3"
-docker_options: ""
+docker_options: "--storage-driver=aufs"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,14 @@
   apt_repository: repo="deb https://apt.dockerproject.org/repo {{ ansible_distribution|lower }}-{{ ansible_distribution_release }} main"
                   state=present
 
+- name: Install AUFS dependencies
+  apt: pkg={{ item }} state=present
+  with_items:
+    - linux-image-extra-{{ ansible_kernel }}
+    - linux-image-extra-virtual
+    - aufs-tools
+  when: docker_options | search("--storage-driver=aufs")
+
 - name: Install Docker
   apt: pkg=docker-engine={{ docker_version }} state=present
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: Configure the Docker APT key
-  apt_key: url=https://get.docker.io/gpg
-           keyserver=p80.pool.sks-keyservers.net
+  apt_key: keyserver=p80.pool.sks-keyservers.net
            id=58118E89F3A912897C070ADBF76221572C52609D
            state=present
 


### PR DESCRIPTION
Docker's official installation Bash script includes a section that defaults the storage driver to AUFS on Debian/Ubuntu based systems. These changes aim to mimic that section with Ansible tasks:

``` bash
# aufs is preferred over devicemapper; try to ensure the driver is available.
if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
    if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | grep -q '^ii' 2>/dev/null; then
        kern_extras="linux-image-extra-$(uname -r) linux-image-extra-virtual"

        apt_get_update
        ( set -x; $sh_c 'sleep 3; apt-get install -y -q '"$kern_extras" ) || true

        if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
            echo >&2 'Warning: tried to install '"$kern_extras"' (for AUFS)'
            echo >&2 ' but we still have no AUFS.  Docker may not work. Proceeding anyways!'
            ( set -x; sleep 10 )
        fi
    else
        echo >&2 'Warning: current kernel is not supported by the linux-image-extra-virtual'
        echo >&2 ' package.  We have no AUFS support.  Consider installing the packages'
        echo >&2 ' linux-image-virtual kernel and linux-image-extra-virtual for AUFS support.'
        ( set -x; sleep 10 )
    fi
fi
```

See also: https://get.docker.com/

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/azavea/ansible-docker/5)

<!-- Reviewable:end -->
