### PR TITLE
Get APT key over port 80

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Configure the Docker APT key
-  apt_key: keyserver=p80.pool.sks-keyservers.net
+  apt_key: keyserver=hkp://p80.pool.sks-keyservers.net:80
            id=58118E89F3A912897C070ADBF76221572C52609D
            state=present
 


### PR DESCRIPTION
HKP uses HTTP over port 11371 by default, but this conflicts with many default firewall settings that only allow outbound HTTP/S.
