### PR TITLE
Use MIT key server for stability

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Configure the Docker APT key
-  apt_key: keyserver=hkp://p80.pool.sks-keyservers.net:80
+  apt_key: keyserver=hkp://pgp.mit.edu:80
            id=58118E89F3A912897C070ADBF76221572C52609D
            state=present
 


### PR DESCRIPTION
The previous key server led to several transient build failures. This change aims to address those failures with what is believed to be a more stable key server.
