### PR TITLE
Add APT repository server variable; Bump Docker versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An Ansible role for installing Docker.
 - `docker_version` - Docker version
 - `docker_py_version` - Docker API client for Python version
 - `docker_options` - Options passed to the Docker daemon
+- `docker_keyserver` - Docker APT repository keyserver to use
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-docker_version: "1.7.*"
-docker_py_version: "1.2.3"
-docker_options: "--storage-driver=aufs"
+docker_version: "1.11.*"
+docker_py_version: "1.8.1"
+docker_options: ""
 docker_keyserver: "hkp://p80.pool.sks-keyservers.net:80"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 docker_version: "1.7.*"
 docker_py_version: "1.2.3"
 docker_options: "--storage-driver=aufs"
+docker_keyserver: "hkp://p80.pool.sks-keyservers.net:80"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Configure the Docker APT key
-  apt_key: keyserver=hkp://pgp.mit.edu:80
-           id=58118E89F3A912897C070ADBF76221572C52609D
+  apt_key: keyserver="{{ docker_keyserver }}"
+           id="58118E89F3A912897C070ADBF76221572C52609D"
            state=present
 
 - name: Configure the Docker APT repository

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,15 +9,16 @@
                   state=present
 
 - name: Install AUFS dependencies
-  apt: pkg={{ item }} state=present
+  apt: pkg="{{ item }}" state=present
   with_items:
-    - linux-image-extra-{{ ansible_kernel }}
-    - linux-image-extra-virtual
-    - aufs-tools
+    - "linux-image-extra-{{ ansible_kernel }}"
+    - "linux-image-extra-virtual"
+    - "aufs-tools"
   when: docker_options | search("--storage-driver=aufs")
 
 - name: Install Docker
-  apt: pkg=docker-engine={{ docker_version }} state=present
+  apt: pkg="docker-engine={{ docker_version }}"
+       state=present
 
 - name: Configure Docker
   template: src=docker.j2 dest=/etc/default/docker
@@ -26,5 +27,5 @@
 
 - name: Install Docker API client for Python
   pip: name=docker-py
-       version={{ docker_py_version }}
+       version="{{ docker_py_version }}"
        state=present


### PR DESCRIPTION
In order to mitigate issues related to key servers being inaccessible, add a new variable that allows users to pass in a custom key server URI. In addition, update the default versions of Docker and docker-py, but ensure that they are compatible. Also, remove AUFS as the default storage engine.

---

**Testing**

Navigate into the `examples` directory and bring the Vagrant box up to interact with the Docker daemon. Also, ensure that the proper APT key is used when Docker is being installed.
