### PR TITLE
Add support for Docker 1.12

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-docker_version: "1.11.*"
-docker_py_version: "1.8.1"
+docker_version: "1.12.*"
+docker_py_version: "1.10.6"
 docker_options: ""
 docker_keyserver: "hkp://p80.pool.sks-keyservers.net:80"

--- a/templates/docker.j2
+++ b/templates/docker.j2
@@ -1,7 +1,14 @@
 # Docker Upstart and SysVinit configuration file
 
+#
+# THIS FILE DOES NOT APPLY TO SYSTEMD
+#
+#   Please see the documentation for "systemd drop-ins":
+#   https://docs.docker.com/engine/articles/systemd/
+#
+
 # Customize location of Docker binary (especially for development testing).
-#DOCKER="/usr/local/bin/docker"
+#DOCKERD="/usr/local/bin/dockerd"
 
 # Use DOCKER_OPTS to modify the daemon startup options.
 DOCKER_OPTS="{{ docker_options }}"


### PR DESCRIPTION
Change the default Docker Engine version to 1.12.*. Also, update the Docker SDK for Python to 1.10.6.

---

**Testing**

Navigate to the `examples` directory and ensure that provisioning via Vagrant completes successfully:

```bash
$ cd examples
$ vagrant up
```