### PR TITLE
Feature/tnation/docker py

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 docker_version: "1.12.*"
-docker_py_version: "1.10.6"
 docker_options: ""
 docker_keyserver: "hkp://p80.pool.sks-keyservers.net:80"

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -10,7 +10,5 @@
 
   tasks:
     - name: Bring up a test container
-      docker:
-        name: test
-        image: busybox
-        state: started
+      command: docker run busybox sh
+      become: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,5 +14,5 @@ galaxy_info:
   - system
 dependencies:
   - src: azavea.pip
-    version: 0.1.0
+    version: 1.0.0
     name: azavea.pip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,8 +24,3 @@
   template: src=docker.j2 dest=/etc/default/docker
   notify:
     - Restart Docker
-
-- name: Install Docker API client for Python
-  pip: name=docker-py
-       version="{{ docker_py_version }}"
-       state=present


### PR DESCRIPTION
Install the Docker SDK instead of docker-py. Also, bump `ansible-pip` role version and update the example installation to be compatible with the new version of docker. 

Fixes https://github.com/azavea/ansible-docker/issues/11

# Testing
```bash
$ cd examples
examples/ $ vagrant up --provision
$ vagrant ssh -c "docker ps"
```