### PR TITLE
Bump Docker version to v17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vagrant
 
-examples/roles/azavea.pip
+examples/roles/*

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ An Ansible role for installing Docker.
 
 ## Role Variables
 
-- `docker_version` - Docker version
+- `docker_version` - Docker version (default `17.*`)
 - `docker_options` - Options passed to the Docker daemon
-- `docker_keyserver` - Docker APT repository keyserver to use
+- `docker_key_url` - Docker APT repository keyserver to use.
+- `docker_package_name` - Name of docker package (`docker-ce` or `docker-ee`, defaults to `docker-ce`
+)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
-docker_version: "1.12.*"
+docker_package_name: "docker-ce"
+docker_version: "17.*"
 docker_options: ""
-docker_keyserver: "hkp://p80.pool.sks-keyservers.net:80"
+docker_repository_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}"

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,2 +1,3 @@
-- src: azavea.pip
-  version: 0.1.1
+---
+- src: azavea.python-security
+  version: 0.1.0

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -6,6 +6,7 @@
       apt: update_cache=yes
 
   roles:
+    - { role: "azavea.python-security", when: 'ansible_python_version | version_compare("2.7.9", "<")' }
     - { role: "azavea.docker" }
 
   tasks:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,4 @@ galaxy_info:
   categories:
   - development
   - system
-dependencies:
-  - src: azavea.pip
-    version: 1.0.0
-    name: azavea.pip
+dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,24 +1,13 @@
 ---
-- name: Configure the Docker APT key
-  apt_key: keyserver="{{ docker_keyserver }}"
-           id="58118E89F3A912897C070ADBF76221572C52609D"
-           state=present
+- name: Download Docker APT key
+  apt_key: url={{ docker_repository_url }}/gpg id=0EBFCD88 state=present
 
 - name: Configure the Docker APT repository
-  apt_repository: repo="deb https://apt.dockerproject.org/repo {{ ansible_distribution|lower }}-{{ ansible_distribution_release }} main"
+  apt_repository: repo="deb {{ docker_repository_url }} {{ ansible_distribution_release }} stable"
                   state=present
 
-- name: Install AUFS dependencies
-  apt: pkg="{{ item }}" state=present
-  with_items:
-    - "linux-image-extra-{{ ansible_kernel }}"
-    - "linux-image-extra-virtual"
-    - "aufs-tools"
-  when: docker_options | search("--storage-driver=aufs")
-
 - name: Install Docker
-  apt: pkg="docker-engine={{ docker_version }}"
-       state=present
+  apt: pkg="{{ docker_package_name }}={{ docker_version }}" state=present
 
 - name: Configure Docker
   template: src=docker.j2 dest=/etc/default/docker

--- a/templates/docker.j2
+++ b/templates/docker.j2
@@ -4,7 +4,7 @@
 # THIS FILE DOES NOT APPLY TO SYSTEMD
 #
 #   Please see the documentation for "systemd drop-ins":
-#   https://docs.docker.com/engine/articles/systemd/
+#   https://docs.docker.com/engine/admin/systemd/
 #
 
 # Customize location of Docker binary (especially for development testing).
@@ -17,4 +17,4 @@ DOCKER_OPTS="{{ docker_options }}"
 #export http_proxy="http://127.0.0.1:3128/"
 
 # This is also a handy place to tweak where Docker's temporary files go.
-#export TMPDIR="/mnt/bigdrive/docker-tmp"
+#export DOCKER_TMPDIR="/mnt/bigdrive/docker-tmp"


### PR DESCRIPTION
# Overview

Docker recently changed their versioning scheme so that the most recent release for Ubuntu is `v17.03.1-ce`. The  version bump is accompanied by a few installation changes, addressed in this PR:

- The Docker GPG key is now served off of S3 (via CloudFront), rather than an keyserver. This module now installs the key by providing the `docker_key_url` to the `apt_key:url` option.
- The `docker-engine` package has been replaced with `docker-ce` (community edition) and `docker-ee` (enterprise edition). I added the `docker_package` variable to allow users to install either.
- The docker apt repo URL has changed. Since the new repo URL varies depending on the edition of docker you want to install, I added the `docker_repository_url` variable.

# Notes
Since the CloudFront distribution that serves the Docker GPG key has [SNI enabled](https://quickscan.networking4all.com/en/results/49a4b36cfcc0822f31e68eeb3be88ff1a768b505#scan), we have to install additional dependencies to use the Ansible `apt_key` module with Python 2.7.6. See ansible/ansible-modules-core#1716 for more information.


# Testing
```bash
$ cd examples/
examples $ vagrant up --provision
```
See [raster-foundry#tba](url)