### PR TITLE
Remove docker_repository_url variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.0
+
+- Remove `docker_repository_url` variable.
+
 ## 4.0.0
 
 - Add support for Docker Community Edition; includes several breaking changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 5.0.0
 
 - Remove `docker_repository_url` variable.
+- Add `docker_repository_arch` variable.
 
 ## 4.0.0
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,3 @@
 docker_package_name: "docker-ce"
 docker_version: "17.*"
 docker_options: ""
-docker_repository_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+docker_repository_arch: "amd64"
 docker_package_name: "docker-ce"
 docker_version: "17.*"
 docker_options: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   apt_key: url=https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg id=0EBFCD88 state=present
 
 - name: Configure the Docker APT repository
-  apt_repository: repo="deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+  apt_repository: repo="deb [arch={{ docker_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
                   state=present
 
 - name: Install Docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Download Docker APT key
-  apt_key: url={{ docker_repository_url }}/gpg id=0EBFCD88 state=present
+  apt_key: url=https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg id=0EBFCD88 state=present
 
 - name: Configure the Docker APT repository
-  apt_repository: repo="deb {{ docker_repository_url }} {{ ansible_distribution_release }} stable"
+  apt_repository: repo="deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
                   state=present
 
 - name: Install Docker


### PR DESCRIPTION
## Overview

This PR removes the `docker_repository_url` variable.

I think this is OK because, since this role depends on Apt, it's most likely only going to be used in Ubuntu or Debian. And since we're depending on a specific public key ID, it's unlikely that this role could ever be used with anything other than the official Docker repo. 

Additionally, the [docs](https://docs.docker.com/install/linux/docker-ce/ubuntu/) say to add `[arch=amd64]` to the sources line, so this aligns us with the "official" way of doing things.

## Testing Instructions

Bring up the `example/` VM and see that the provisioning is successful:

```bash
$ cd examples
$ vagrant up
...
TASK [azavea.docker : Download Docker APT key] *********************************
changed: [default]

TASK [azavea.docker : Configure the Docker APT repository] *********************
changed: [default]

TASK [azavea.docker : Install Docker] ******************************************
changed: [default]

TASK [azavea.docker : Configure Docker] ****************************************
changed: [default]

TASK [Bring up a test container] ***********************************************
changed: [default]

RUNNING HANDLER [azavea.docker : Restart Docker] *******************************
changed: [default]

PLAY RECAP *********************************************************************
default                    : ok=12   changed=10   unreachable=0    failed=0
```

Also, see https://github.com/hunchlab/hunchlab/pull/281.