### PR TITLE
Add support for installing multiple Docker packages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Azavea Inc.
+   Copyright 2020 Azavea Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An Ansible role for installing Docker.
 ## Role Variables
 
 - `docker_repository_arch` - Architecture for Docker package repository (default: `amd64`)
-- `docker_packages` - Names of Docker packages (default: `docker-ce`, `docker-ce-cli`, `containerd.io`)
+- `docker_packages` - Names of Docker packages (default: `docker-ce=docker_version`, `docker-ce-cli=docker_version`, `containerd.io=docker_containerd_version`)
 - `docker_version` - Docker version (default `5:19.*`)
 - `docker_containerd_version`: Containerd version (default: `1.2.*`)
 - `docker_options` - Options passed to the Docker daemon

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ An Ansible role for installing Docker.
 
 ## Role Variables
 
-- `docker_repository_arch` - Arch version of docker package (default `amd64`)
-- `docker_package_name` - Name of docker package (`docker-ce` or `docker-ee`, defaults to `docker-ce`)
-- `docker_version` - Docker version (default `17.*`)
+- `docker_repository_arch` - Architecture for Docker package repository (default: `amd64`)
+- `docker_packages` - Names of Docker packages (default: `docker-ce`, `docker-ce-cli`, `containerd.io`)
+- `docker_version` - Docker version (default `5:19.*`)
+- `docker_containerd_version`: Containerd version (default: `1.2.*`)
 - `docker_options` - Options passed to the Docker daemon
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 docker_repository_arch: "amd64"
-docker_package_name: "docker-ce"
-docker_version: "17.*"
+docker_packages:
+  - "docker-ce={{ docker_version }}"
+  - "docker-ce-cli={{ docker_version }}"
+  - "containerd.io={{ docker_containerd_version }}"
+docker_version: "5:19.*"
+docker_containerd_version: "1.2.*"
 docker_options: ""

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -3,22 +3,22 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
-# Ensure role dependencies are in place
-if [ "up", "provision" ].include?(ARGV.first) &&
-  !(File.directory?("roles/azavea.pip") || File.symlink?("roles/azavea.pip"))
-
-  unless system("ansible-galaxy install --force -r roles.yml -p roles")
-    $stderr.puts "\nERROR: Please install Ansible 1.4.2+ so that the ansible-galaxy binary"
-    $stderr.puts "is available."
-    exit(1)
-  end
-end
-
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.define "xenial" do |xenial|
+    xenial.vm.box = "bento/ubuntu-16.04"
 
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "site.yml"
-    ansible.sudo = true
+    xenial.vm.provision "ansible" do |ansible|
+      ansible.playbook = "site.yml"
+      ansible.become = true
+    end
+  end
+
+  config.vm.define "buster" do |buster|
+    buster.vm.box = "bento/ubuntu-18.04"
+
+    buster.vm.provision "ansible" do |ansible|
+      ansible.playbook = "site.yml"
+      ansible.become = true
+    end
   end
 end

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,3 +1,0 @@
----
-- src: azavea.python-security
-  version: 0.1.0

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -3,13 +3,12 @@
 
   pre_tasks:
     - name: Update APT cache
-      apt: update_cache=yes
+      apt:
+        update_cache: yes
 
   roles:
-    - { role: "azavea.python-security", when: 'ansible_python_version | version_compare("2.7.9", "<")' }
     - { role: "azavea.docker" }
 
   tasks:
     - name: Bring up a test container
       command: docker run busybox sh
-      become: yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,5 @@
 ---
 - name: Restart Docker
-  service: name=docker state=restarted
+  service:
+    name: docker
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An Ansible role for installing Docker.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 2.8
+  min_ansible_version: 2.6
   platforms:
     - name: Ubuntu
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,12 +4,13 @@ galaxy_info:
   description: An Ansible role for installing Docker.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.9.2
+  min_ansible_version: 2.8
   platforms:
-  - name: Ubuntu
-    versions:
-    - trusty
+    - name: Ubuntu
+      versions:
+        - xenial
+        - buster
   categories:
-  - development
-  - system
+    - development
+    - system
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,24 @@
 ---
 - name: Download Docker APT key
-  apt_key: url=https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg id=0EBFCD88 state=present
+  apt_key:
+    url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+    id: 0EBFCD88
+    state: present
 
 - name: Configure the Docker APT repository
-  apt_repository: repo="deb [arch={{ docker_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
-                  state=present
+  apt_repository:
+    repo: |
+      deb [arch={{ docker_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
+    state: present
 
 - name: Install Docker
-  apt: pkg="{{ docker_package_name }}={{ docker_version }}" state=present
+  apt:
+    pkg: "{{ docker_packages }}"
+    state: present
 
 - name: Configure Docker
-  template: src=docker.j2 dest=/etc/default/docker
+  template:
+    src: docker.j2
+    dest: /etc/default/docker
   notify:
     - Restart Docker


### PR DESCRIPTION
Recently, the official Docker [installation instructions](https://docs.docker.com/engine/install/ubuntu/) for Ubuntu added an additional set of packages necessary to install all of the most common components of Docker (`containerd`, daemon, CLI). These changes update the module to support the installation of multiple Docker packages vs. just one.

In addition:

- The default version of Docker installed was updated to 19.x
- The YAML syntax for all Ansible playbooks was updated
- Support for Xenial (16.04) and Buster (18.04) was officially added (testing too)

Fixes https://github.com/azavea/ansible-docker/issues/17
Connects https://github.com/WikiWatershed/model-my-watershed/issues/3322

---

### Testing

- Navigate to the `examples` directory and instantiate the Vagrant project

```console
$ cd examples
$ vagrant up
```

- Ensure both the `xenial` and `buster` virtual machines provision cleanly

- SSH into either virtual machine and confirm that a consistent version of the daemon and CLI was installed

```console
$ vagrant ssh xenial
vagrant@vagrant:~$ sudo apt list --installed | grep docker

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

docker-ce/xenial,now 5:19.03.9~3-0~ubuntu-xenial amd64 [installed]
docker-ce-cli/xenial,now 5:19.03.9~3-0~ubuntu-xenial amd64 [installed]
```