### PR TITLE
Add mode to apt source file to suppress warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
   apt_repository:
     repo: |
       deb [arch={{ docker_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
+    mode: '0600'
     state: present
 
 - name: Install Docker


### PR DESCRIPTION
Adding the repo triggered a warning:

`[WARNING]: File '/etc/apt/sources.list.d/download_docker_com_linux_ubuntu.list' created with default permissions '600'. The previous default was '666'. Specify 'mode' to avoid this warning.`

Adding mode 0600 will prevent this and create a secure file.