### PR TITLE
Install APT packages for Docker

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,11 @@
 ---
 docker_repository_arch: "amd64"
+docker_required_packages:
+  - "apt-transport-https"
+  - "ca-certificates"
+  - "curl"
+  - "gnupg-agent"
+  - "software-properties-common"
 docker_packages:
   - "docker-ce={{ docker_version }}"
   - "docker-ce-cli={{ docker_version }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install required packages
+  apt:
+    pkg: "{{ docker_required_packages }}"
+    state: present
+
 - name: Download Docker APT key
   apt_key:
     url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg


### PR DESCRIPTION
Installation on a clean, minimal install of Ubuntu 20.04 fails with the following error:

> fatal: [docker]: FAILED! => {"changed": false, "msg": "Failed to find required executable gpg in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"}

This patch installs the packages as described on the [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) page.

This might also fix #15.
